### PR TITLE
Override inherited keys() method to force the lazy getter execution

### DIFF
--- a/unipop-elastic2/src/org/unipop/elastic2/controller/vertex/ElasticVertex.java
+++ b/unipop-elastic2/src/org/unipop/elastic2/controller/vertex/ElasticVertex.java
@@ -7,6 +7,7 @@ import org.unipop.structure.*;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 public class ElasticVertex<T extends ElasticVertexController> extends BaseVertex<T> {
@@ -42,7 +43,7 @@ public class ElasticVertex<T extends ElasticVertexController> extends BaseVertex
             e.printStackTrace();
         }
     }
-
+    
     @Override
     public <V> VertexProperty<V> property(final String key) {
         checkLazy();
@@ -63,6 +64,12 @@ public class ElasticVertex<T extends ElasticVertexController> extends BaseVertex
     public <V> Iterator<VertexProperty<V>> properties(final String... propertyKeys) {
         checkLazy();
         return super.properties(propertyKeys);
+    }
+    
+    @Override
+    public Set<String> keys() {
+    	checkLazy();
+        return this.properties.keySet();
     }
 
     protected void checkLazy() {

--- a/unipop-elastic2/src/org/unipop/elastic2/controller/vertex/ElasticVertex.java
+++ b/unipop-elastic2/src/org/unipop/elastic2/controller/vertex/ElasticVertex.java
@@ -43,7 +43,7 @@ public class ElasticVertex<T extends ElasticVertexController> extends BaseVertex
             e.printStackTrace();
         }
     }
-    
+
     @Override
     public <V> VertexProperty<V> property(final String key) {
         checkLazy();
@@ -66,11 +66,11 @@ public class ElasticVertex<T extends ElasticVertexController> extends BaseVertex
         return super.properties(propertyKeys);
     }
     
-    @Override
-    public Set<String> keys() {
-    	checkLazy();
-        return this.properties.keySet();
-    }
+	@Override
+	public Set<String> keys() {
+		checkLazy();
+		return this.properties.keySet();
+	}
 
     protected void checkLazy() {
         if (lazyGetter != null) lazyGetter.execute();


### PR DESCRIPTION
Close https://github.com/sirensolutions/unipop/issues/3
